### PR TITLE
Fixing SourceDrop

### DIFF
--- a/Tasks/DacPacReport/DacPacReport.ps1
+++ b/Tasks/DacPacReport/DacPacReport.ps1
@@ -105,6 +105,7 @@ function Download-BuildDrop {
                 Remove-Item -Path $tPath -Recurse -Force
             }
             mkdir $tPath
+            
             Add-Type -AssemblyName "System.IO.Compression.FileSystem"
             [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $tPath)
         }

--- a/Tasks/DacPacReport/DacPacReport.ps1
+++ b/Tasks/DacPacReport/DacPacReport.ps1
@@ -99,11 +99,12 @@ function Download-BuildDrop {
             Write-Verbose -Verbose "Expand-Archive does not exist. Using System.IO.Compression.ZipFile"
             
             $zipPath = Resolve-Path ".\$DropName.zip"
-            $tPath = Resolve-Path ".\SourceDrop"
+            $tPath = ".\SourceDrop"
 
             if (Test-Path -Path $tPath) {
                 Remove-Item -Path $tPath -Recurse -Force
             }
+            mkdir $tPath
             Add-Type -AssemblyName "System.IO.Compression.FileSystem"
             [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $tPath)
         }

--- a/Tasks/DacPacReport/task.json
+++ b/Tasks/DacPacReport/task.json
@@ -16,7 +16,7 @@
   "version": {
     "Major": "0",
     "Minor": "0",
-    "Patch": "1"
+    "Patch": "2"
   },
   "minimumAgentVersion": "1.103.0",
   "instanceNameFormat": "DacPac Schema Compare $(dacpacName).dacpac",

--- a/extension-manifest.json
+++ b/extension-manifest.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "colinsalmcorner-buildtasks",
     "name": "Colin's ALM Corner Build & Release Tools",
-    "version": "1.0.34",
+    "version": "1.0.35",
     "publisher": "colinsalmcorner",
     "public": true,
     "targets": [

--- a/extension-overview.md
+++ b/extension-overview.md
@@ -26,4 +26,4 @@ This extension contains helpful build and release Tasks.
 	> The [Azure RM WebApp Deploy Task](https://github.com/Microsoft/vsts-tasks/tree/master/Tasks/AzureRmWebAppDeployment) now does everything this task does, so I'm deprecating this task.
 
 ## Source Code
-The source repo for this extension is [on Github.](https://github.com/colindembovsky/cols-agent-task)
+The source repo for this extension is [on Github.](https://github.com/colindembovsky/cols-agent-tasks)


### PR DESCRIPTION
This fixes #27. It turns out that when using Extract-Archive, Find-Files returns a single file. When using System.IO.Compression.FileSystem, the Find-Files method returns an array. Go figure.