### PR TITLE
Fix minor spelling errors in help text

### DIFF
--- a/Tasks/ReplaceTokens/task.json
+++ b/Tasks/ReplaceTokens/task.json
@@ -30,7 +30,7 @@
       "type": "filePath",
       "label": "Source Path",
       "defaultValue": "",
-      "helpMarkDown": "Path to the file(s) containing tokens. NOTE: this is casese sensitive for non-Windows systems. This should be a path containing the file, not the file itself.",
+      "helpMarkDown": "Path to the file(s) containing tokens. NOTE: this is case sensitive for non-Windows systems. This should be a path containing the file, not the file itself.",
       "required": true
     },
     {
@@ -38,7 +38,7 @@
       "type": "string",
       "label": "Target File Pattern",
       "defaultValue": "*.config",
-      "helpMarkDown": "File pattern to find in source path. Supports minimatch. NOTE: this is casese sensitive for non-Windows systems.",
+      "helpMarkDown": "File pattern to find in source path. Supports minimatch. NOTE: this is case sensitive for non-Windows systems.",
       "required": true
     },
     {

--- a/Tasks/Tokenizer/task.json
+++ b/Tasks/Tokenizer/task.json
@@ -23,7 +23,7 @@
       "type": "filePath",
       "label": "Source Path",
       "defaultValue": "",
-      "helpMarkDown": "Path to the file(s) containing files to tokenize. NOTE: this is casese sensitive for non-Windows systems. This should be a path containing the file, not the file itself.",
+      "helpMarkDown": "Path to the file(s) containing files to tokenize. NOTE: this is case sensitive for non-Windows systems. This should be a path containing the file, not the file itself.",
       "required": true
     },
     {
@@ -31,7 +31,7 @@
       "type": "string",
       "label": "File Pattern",
       "defaultValue": "appsettings.json",
-      "helpMarkDown": "File pattern to find in source path. Supports minimatch. NOTE: this is casese sensitive for non-Windows systems.",
+      "helpMarkDown": "File pattern to find in source path. Supports minimatch. NOTE: this is case sensitive for non-Windows systems.",
       "required": true
     },
     {

--- a/Tasks/VersionAssemblies/task.json
+++ b/Tasks/VersionAssemblies/task.json
@@ -31,7 +31,7 @@
       "label": "Source Path",
       "defaultValue": "",
       "required": true,
-      "helpMarkDown": "Path in which to search for version files (like AssemblyInfo.* files). NOTE: this is casese sensitive for non-Windows systems." 
+      "helpMarkDown": "Path in which to search for version files (like AssemblyInfo.* files). NOTE: this is case sensitive for non-Windows systems." 
     },
     {
       "name": "filePattern",
@@ -39,7 +39,7 @@
       "label": "File Pattern",
       "defaultValue": "**\\AssemblyInfo.*",
       "required": true,
-      "helpMarkDown": "File filter to replace version info. The version number pattern should exist somewhere in the file(s). Supports minimatch. NOTE: this is casese sensitive for non-Windows systems."
+      "helpMarkDown": "File filter to replace version info. The version number pattern should exist somewhere in the file(s). Supports minimatch. NOTE: this is case sensitive for non-Windows systems."
     },
     {
       "name": "buildRegex",


### PR DESCRIPTION
Correct the misspelling of "case" in the help text for the following 3 tasks:
- Replace Tokens
- Tokenizer
- Version Assemblies