### PR TITLE
Ignore nulls in tokenizer task, bump version

### DIFF
--- a/Tasks/Tokenizer/task.json
+++ b/Tasks/Tokenizer/task.json
@@ -13,7 +13,7 @@
   "version": {
     "Major": "1",
     "Minor": "2",
-    "Patch": "27"
+    "Patch": "28"
   },
   "minimumAgentVersion": "1.91.0",
   "instanceNameFormat": "Tokenize file(s)",

--- a/Tasks/Tokenizer/tokenizer.ts
+++ b/Tasks/Tokenizer/tokenizer.ts
@@ -5,6 +5,10 @@ import * as os from 'os';
 
 function replaceProps(obj: any, parent: string, includeSet: Set<string>, excludeSet: Set<string>) {
     for (let prop of Object.getOwnPropertyNames(obj)) {
+        if (obj[prop] == null) {
+            continue;
+        }
+
         let propPath = parent === '' ? `${prop}` : `${parent}.${prop}`;
         if (obj[prop] instanceof Array) {
             obj[prop].forEach((arrayObj, position) => {


### PR DESCRIPTION
This fixes #90, which I also ran into recently.

This could potentially also be fixed by assuming a default type for nulls (probably string), but I think this solution represents the more commonly expected behavior.