### PR TITLE
Support zip files in replace tokens task

### DIFF
--- a/Tasks/ReplaceTokens/README.md
+++ b/Tasks/ReplaceTokens/README.md
@@ -11,7 +11,7 @@ steps:
 - task: colinsalmcorner.colinsalmcorner-buildtasks.replace-tokens-task.ReplaceTokens@1
   displayName: 'Replace tokens in MyPath.'
   inputs:
-    sourcePath: MyPath  # Root path to find files in.
+    sourcePath: MyPath  # Root path to find files in. Can be a directory or zip file.
     filePattern: **\*.release.config  # file pattern (glob) to search within root path. All matching files will be updated.
     # tokenRegex: '__(\w+)__'  # regex pattern to use to find tokens
     # secretTokens: df  # DO NOT USE UNLESS YOU'RE ON TFS 2015. Specify the secret values here
@@ -38,7 +38,7 @@ Imagine you have a file with the following contents:
 <?xml version="1.0" encoding="utf-8"?>
 <parameters>
   <setParameter name="IIS Web Application Name" value="__SiteName__" />
-</parameters>  
+</parameters>
 ```
 
 This file contains a token called "SiteName".
@@ -63,16 +63,16 @@ You can see all the environment variables in the logs for a deployment.
 
 1. Secrets
 
-    Since the native [vso-task-lib](https://github.com/Microsoft/vsts-task-lib) does not support secrets for 
+    Since the native [vso-task-lib](https://github.com/Microsoft/vsts-task-lib) does not support secrets for
     Node (it does for PowerShell) there is a hack that allows you to specify secrets as an advanced parameter.
-    You specify them in key-value pairs (with the key being the name and the value being the secret variable) 
+    You specify them in key-value pairs (with the key being the name and the value being the secret variable)
     and can use a semi-colon to separate them:
-    
+
     ```
     key1:$(secret1);key2:$(secret2)
     ```
-    
-    Hopefully [this issue](https://github.com/Microsoft/vsts-task-lib/issues/48) will be implemented and I can 
+
+    Hopefully [this issue](https://github.com/Microsoft/vsts-task-lib/issues/48) will be implemented and I can
     remove this "hack" - thanks to [Di](https://github.com/dixu99) for the contribution!
 
 ## Using Tokenizer with ReplaceTokens

--- a/Tasks/ReplaceTokens/package-lock.json
+++ b/Tasks/ReplaceTokens/package-lock.json
@@ -1,0 +1,98 @@
+{
+  "name": "colinsalmcornerbuildtasksreplacetokens",
+  "version": "0.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "adm-zip": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",
+      "integrity": "sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    }
+  }
+}

--- a/Tasks/ReplaceTokens/package-lock.json
+++ b/Tasks/ReplaceTokens/package-lock.json
@@ -12,10 +12,33 @@
         "@types/node": "*"
       }
     },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+    },
     "@types/node": {
       "version": "14.0.27",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
       "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+    },
+    "@types/rimraf": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-3.0.0.tgz",
+      "integrity": "sha512-7WhJ0MdpFgYQPXlF4Dx+DhgvlPCfz/x5mHaeDQAKhcenvQP1KCpLQ18JklAqeGMYSAT2PxLpzd0g2/HE7fj7hQ==",
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "adm-zip": {
       "version": "0.4.16",

--- a/Tasks/ReplaceTokens/package-lock.json
+++ b/Tasks/ReplaceTokens/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/adm-zip": {
+      "version": "0.4.33",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.33.tgz",
+      "integrity": "sha512-WM0DCWFLjXtddl0fu0+iN2ZF+qz8RF9RddG5OSy/S90AQz01Fu8lHn/3oTIZDxvG8gVcnBLAHMHOdBLbV6m6Mw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "14.0.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+    },
     "adm-zip": {
       "version": "0.4.16",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.16.tgz",

--- a/Tasks/ReplaceTokens/package.json
+++ b/Tasks/ReplaceTokens/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@types/adm-zip": "^0.4.33",
     "@types/node": "^14.0.27",
+    "@types/rimraf": "^3.0.0",
     "adm-zip": "^0.4.16",
     "rimraf": "^3.0.2"
   }

--- a/Tasks/ReplaceTokens/package.json
+++ b/Tasks/ReplaceTokens/package.json
@@ -26,6 +26,8 @@
     "shelljs": "^0.8.3"
   },
   "dependencies": {
+    "@types/adm-zip": "^0.4.33",
+    "@types/node": "^14.0.27",
     "adm-zip": "^0.4.16",
     "rimraf": "^3.0.2"
   }

--- a/Tasks/ReplaceTokens/package.json
+++ b/Tasks/ReplaceTokens/package.json
@@ -24,5 +24,9 @@
     "azure-pipelines-task-lib": "^2.9.3",
     "minimatch": "^3.0.4",
     "shelljs": "^0.8.3"
+  },
+  "dependencies": {
+    "adm-zip": "^0.4.16",
+    "rimraf": "^3.0.2"
   }
 }

--- a/Tasks/ReplaceTokens/replaceTokens.ts
+++ b/Tasks/ReplaceTokens/replaceTokens.ts
@@ -3,7 +3,7 @@ import * as sh from 'shelljs';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as AdmZip from 'adm-zip';
-const rimraf = require("rimraf");
+import * as rimraf from 'rimraf'
 
 async function run() {
     var errCount = 0;
@@ -144,7 +144,7 @@ async function run() {
             zip.writeZip(sourcePathZipFilePath);
 
             tl.debug(`Deleting temp directory '${sourcePathZipDirectoryPath}'.`)
-            rimraf(sourcePathZipDirectoryPath, function () { tl.debug(`Temp directory '${sourcePathZipDirectoryPath}' has been deleted.`) });
+            rimraf.sync(sourcePathZipDirectoryPath);
         }
     } catch (err) {
         let msg = err;

--- a/Tasks/ReplaceTokens/task.json
+++ b/Tasks/ReplaceTokens/task.json
@@ -30,7 +30,7 @@
       "type": "filePath",
       "label": "Source Path",
       "defaultValue": "",
-      "helpMarkDown": "Path to the file(s) containing tokens. Leave empty to use the sources directory. NOTE: this is case sensitive for non-Windows systems. This should be a path containing the file, not the file itself.",
+      "helpMarkDown": "Path to the file(s) containing tokens. Leave empty to use the sources directory. NOTE: this is case sensitive for non-Windows systems. This should be a directory or zip file path containing the file, not the file itself.",
       "required": false
     },
     {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
   },
   "main": "index.js",
   "dependencies": {
+    "@types/adm-zip": "^0.4.33",
+    "adm-zip": "^0.4.16",
     "azure-devops-node-api": "^9.0.1",
     "azure-pipelines-task-lib": "^2.8.0",
     "process": "^0.11.10",

--- a/test/replaceTokens/test-zipFile.ts
+++ b/test/replaceTokens/test-zipFile.ts
@@ -1,0 +1,80 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+import fs = require('fs');
+import * as AdmZip from 'adm-zip';
+
+let rootDir = path.join(__dirname, '../../Tasks', 'ReplaceTokens');
+let taskPath = path.join(rootDir, 'replaceTokens.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+// set up a tmp file for the test
+var workingFolder = path.join(__dirname, "working");
+if (!fs.existsSync(workingFolder)) {
+  fs.mkdirSync(workingFolder);
+}
+var tmpFile = path.join(workingFolder, "file.config");
+
+// provide answers for task mock
+let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+    "checkPath": {
+        "working": true
+    },
+    "findMatch": {
+        "*.config" : [ tmpFile ]
+    }
+};
+tmr.setAnswers(a);
+
+fs.writeFile(tmpFile, `
+<configuration>
+  <appSettings>
+    <add key="CoolKey" value="__CoolKey__" />
+    <add key="Secret1" value="__Secret1__" />
+  </appSettings>
+</configuration>
+`,
+    (err) => {
+
+        // Zip up file to be token replaced.
+        let zipFilePath = path.join(workingFolder, "Archive.zip");
+        const zip = AdmZip();
+        zip.addLocalFile(tmpFile);
+        zip.writeZip(zipFilePath)
+
+        // set inputs
+        tmr.setInput('sourcePath', "working/Archive.zip");
+        tmr.setInput('filePattern', '*.config');
+        tmr.setInput('tokenRegex', '__(\\w+)__');
+
+        // set variables
+        process.env["COOLKEY"] = "MyCoolKey";
+        process.env["SECRET_Secret1"] = "supersecret1";
+
+        tmr.run();
+
+        // Unzip the file so we can make sure the tokens were replaced properly.
+        let unzipDirectoryPath = path.join(workingFolder, "Replaced");
+        const unzip = new AdmZip(zipFilePath);
+        unzip.extractAllTo()
+        let replacedFilePath = path.join(unzipDirectoryPath, "file.config")
+
+        // validate the replacement
+        let actual = fs.readFileSync(replacedFilePath).toString();
+        var expected = `
+<configuration>
+  <appSettings>
+    <add key="CoolKey" value="MyCoolKey" />
+    <add key="Secret1" value="supersecret1" />
+  </appSettings>
+</configuration>
+        `;
+
+        if (actual.trim() !== expected.trim()) {
+            console.log(actual);
+            console.error("Replacement failed.");
+        } else {
+            console.log("Replacement succeeded!")
+        }
+    }
+);

--- a/test/replaceTokens/test-zipFile.ts
+++ b/test/replaceTokens/test-zipFile.ts
@@ -38,7 +38,7 @@ fs.writeFile(tmpFile, `
 
         // Zip up file to be token replaced.
         let zipFilePath = path.join(workingFolder, "Archive.zip");
-        const zip = AdmZip();
+        const zip = new AdmZip();
         zip.addLocalFile(tmpFile);
         zip.writeZip(zipFilePath)
 
@@ -56,7 +56,7 @@ fs.writeFile(tmpFile, `
         // Unzip the file so we can make sure the tokens were replaced properly.
         let unzipDirectoryPath = path.join(workingFolder, "Replaced");
         const unzip = new AdmZip(zipFilePath);
-        unzip.extractAllTo()
+		unzip.extractAllTo(unzipDirectoryPath)
         let replacedFilePath = path.join(unzipDirectoryPath, "file.config")
 
         // validate the replacement


### PR DESCRIPTION
feat: Adds support for the Source Path to be a zip file, in which it will extract the contents before doing the token replacement, and then zip the files back up once done.

This addresses #151 

Note: I've never actually done TypeScript or Node development before, so a lot of this was new to me (e.g. package.json, etc.), so hopefully I've adhered to your standards. Apparently breakpoint debugging is broken on my local machine's VS Code, so while I could "run" the code, I couldn't debug it very well. While I'm fairly confident in the code I've written, I wasn't able to extensively test it out, so you will likely want to pull down the branch and run the test I wrote manually to ensure it all works as expected. When I ran the test it seemed to be creating the zip file alright, but not actually swapping the token values, but I think that may be due to me having things misconfigured; as I mentioned, this is all new to me. So do a quick test, hopefully it all works as expected; if not, you should be 98% of the way there with just a bit of debugging to find anything that may be amiss.

Thanks for this great extension! This feature is going to save a lot of our teams a lot of boilerplate code :) 